### PR TITLE
Renaming master > main in GH Actions

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -4,7 +4,7 @@ name: Linters
 on:
   push:
     branches-ignore:
-      - master
+      - main
 
 jobs:
   # https://github.com/github/super-linter

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -3,7 +3,7 @@ name: Standard
 on:
   push:
     branches-ignore:
-      - master
+      - main
 jobs:
   standard:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I switch to using the `main` branch, so making sure the GitHub Actions still work.